### PR TITLE
Standardize module-proxy build process

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -1,0 +1,155 @@
+name: Build and Publish
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Full history for versioning
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Cache Gradle packages
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build and test with Gradle
+        env:
+          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./gradlew clean build test --no-daemon --refresh-dependencies
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: build/test-results/
+
+  publish-snapshots:
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Cache Gradle packages
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Configure GPG (if available)
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+        if: env.GPG_PRIVATE_KEY != ''
+        run: |
+          echo "$GPG_PRIVATE_KEY" | gpg --batch --import
+
+      - name: Publish snapshots to Central
+        env:
+          MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        run: ./gradlew publishAllPublicationsToCentralPortalSnapshots --no-daemon --stacktrace
+
+      - name: Publish snapshots to GitHub Packages
+        env:
+          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./gradlew publish -PskipCentral=true --no-daemon --stacktrace
+
+  docker-snapshot:
+    runs-on: ubuntu-latest
+    needs:
+      - build
+      - publish-snapshots
+    if: github.ref == 'refs/heads/main'
+    permissions:
+      contents: write
+      packages: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Cache Gradle packages
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push snapshot Docker image
+        run: |
+          ./gradlew clean build -x test \
+            -Dquarkus.container-image.build=true \
+            -Dquarkus.container-image.push=true \
+            -Dquarkus.container-image.registry=ghcr.io \
+            -Dquarkus.container-image.group=ai-pipestream \
+            -Dquarkus.container-image.name=module-proxy \
+            -Dquarkus.container-image.tag=${{ github.ref_name }}-${{ github.sha }} \
+            -Dquarkus.container-image.additional-tags=${{ github.sha }} \
+            --no-daemon

--- a/.github/workflows/dockerhub-publish.yml
+++ b/.github/workflows/dockerhub-publish.yml
@@ -1,0 +1,50 @@
+name: Docker Hub Publish
+
+on:
+  repository_dispatch:
+    types: [dockerhub-publish]
+
+jobs:
+  push-to-dockerhub:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - name: Validate payload
+        run: |
+          echo "Payload: ${{ toJson(github.event.client_payload) }}"
+          if [ -z "${{ github.event.client_payload.base_image }}" ] || [ -z "${{ github.event.client_payload.dockerhub_repo }}" ] || [ -z "${{ github.event.client_payload.tags }}" ]; then
+            echo "Missing required client_payload fields: base_image, dockerhub_repo, tags" >&2
+            exit 1
+          fi
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+
+      - name: Pull from GHCR, retag, and push to Docker Hub
+        env:
+          BASE_IMAGE: ${{ github.event.client_payload.base_image }}
+          DOCKERHUB_REPO: ${{ github.event.client_payload.dockerhub_repo }}
+          TAGS: ${{ github.event.client_payload.tags }}
+        run: |
+          set -euo pipefail
+          echo "Processing tags: $TAGS"
+          for TAG in $TAGS; do
+            echo "Pulling $BASE_IMAGE:$TAG"
+            docker pull "$BASE_IMAGE:$TAG"
+            echo "Tagging to $DOCKERHUB_REPO:$TAG"
+            docker tag "$BASE_IMAGE:$TAG" "$DOCKERHUB_REPO:$TAG"
+            echo "Pushing $DOCKERHUB_REPO:$TAG"
+            docker push "$DOCKERHUB_REPO:$TAG"
+          done

--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -1,0 +1,270 @@
+name: Release and Publish
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_type:
+        description: 'Release type (patch, minor, major, or manual)'
+        required: true
+        default: 'patch'
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+          - manual
+      custom_version:
+        description: 'Custom version (only for manual release type, e.g., 1.0.0)'
+        required: false
+        type: string
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Cache Gradle packages
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build and test with Gradle
+        env:
+          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./gradlew clean build test --no-daemon --refresh-dependencies
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: build/test-results/
+
+  release:
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      contents: write
+      packages: write
+    outputs:
+      version: ${{ steps.get_version.outputs.version }}
+      tag: ${{ steps.get_version.outputs.tag }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Cache Gradle packages
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Determine version
+        id: get_version
+        run: |
+          if [ "${{ inputs.release_type }}" == "manual" ]; then
+            VERSION="${{ inputs.custom_version }}"
+          else
+            # Get current version from axion-release
+            CURRENT=$(./gradlew currentVersion -q --no-daemon | tail -1)
+            echo "Raw version output: $CURRENT"
+
+            # Strip "Project version: " prefix if present
+            CURRENT=${CURRENT#Project version: }
+            echo "Parsed version: $CURRENT"
+
+            # Remove -SNAPSHOT suffix if present
+            CURRENT=${CURRENT%-SNAPSHOT}
+
+            # Parse version components
+            IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT"
+
+            case "${{ inputs.release_type }}" in
+              major)
+                VERSION="$((MAJOR + 1)).0.0"
+                ;;
+              minor)
+                VERSION="${MAJOR}.$((MINOR + 1)).0"
+                ;;
+              patch)
+                VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))"
+                ;;
+            esac
+          fi
+
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "tag=v$VERSION" >> $GITHUB_OUTPUT
+          echo "Release version: $VERSION"
+
+      - name: Create release tag
+        run: |
+          git tag -a "${{ steps.get_version.outputs.tag }}" -m "Release ${{ steps.get_version.outputs.version }}"
+          git push origin "${{ steps.get_version.outputs.tag }}"
+
+      - name: Configure GPG (if available)
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+        if: env.GPG_PRIVATE_KEY != ''
+        run: |
+          echo "$GPG_PRIVATE_KEY" | gpg --batch --import
+
+      - name: Publish to Maven Central
+        env:
+          MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        run: ./gradlew publishAllPublicationsToCentralPortal --no-daemon --stacktrace
+
+      - name: Publish to GitHub Packages
+        env:
+          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./gradlew publish -PskipCentral=true --no-daemon --stacktrace
+
+      - name: Build release artifacts
+        run: |
+          ./gradlew clean build -x test --no-daemon
+          mkdir -p release-assets
+          cp build/libs/*.jar release-assets/
+          cp DOCKER_RUN.md release-assets/ 2>/dev/null || true
+          cp README.md release-assets/
+          cd release-assets && zip -r ../module-proxy-${{ steps.get_version.outputs.version }}.zip . && cd ..
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ steps.get_version.outputs.tag }}
+          name: Release ${{ steps.get_version.outputs.version }}
+          body: |
+            ## Module Proxy ${{ steps.get_version.outputs.version }}
+
+            ### Maven Coordinates
+            ```xml
+            <dependency>
+              <groupId>ai.pipestream</groupId>
+              <artifactId>module-proxy</artifactId>
+              <version>${{ steps.get_version.outputs.version }}</version>
+            </dependency>
+            ```
+
+            ### Docker Images
+            - GHCR: `ghcr.io/ai-pipestream/module-proxy:${{ steps.get_version.outputs.version }}`
+            - Docker Hub: `pipestreamai/module-proxy:${{ steps.get_version.outputs.version }}`
+
+            ### Changes
+            See commit history for detailed changes.
+          files: |
+            module-proxy-${{ steps.get_version.outputs.version }}.zip
+          draft: false
+          prerelease: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  docker-production:
+    runs-on: ubuntu-latest
+    needs: release
+    permissions:
+      contents: write
+      packages: write
+    steps:
+      - name: Checkout release tag
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.release.outputs.tag }}
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Cache Gradle packages
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        run: |
+          ./gradlew clean build -x test \
+            -Dquarkus.container-image.build=true \
+            -Dquarkus.container-image.push=true \
+            -Dquarkus.container-image.registry=ghcr.io \
+            -Dquarkus.container-image.group=ai-pipestream \
+            -Dquarkus.container-image.name=module-proxy \
+            -Dquarkus.container-image.tag=${{ needs.release.outputs.version }} \
+            -Dquarkus.container-image.additional-tags=latest \
+            --no-daemon
+
+      - name: Trigger Docker Hub publish
+        if: success()
+        continue-on-error: true
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.DISPATCH_TOKEN }}
+          repository: ${{ github.repository }}
+          event-type: dockerhub-publish
+          client-payload: |
+            {
+              "base_image": "ghcr.io/ai-pipestream/module-proxy",
+              "dockerhub_repo": "pipestreamai/module-proxy",
+              "tags": "${{ needs.release.outputs.version }} latest"
+            }

--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,26 @@
+import org.gradle.plugins.signing.Sign
+
 plugins {
+    id 'pl.allegro.tech.build.axion-release' version '1.21.0'
     alias(libs.plugins.java)
     alias(libs.plugins.quarkus)
     alias(libs.plugins.maven.publish)
-
     id 'signing'
-    id 'com.gradleup.nmcp' version '1.2.0'
+    id 'com.gradleup.nmcp' version '1.2.1'
 }
-def pipelineBomVersion = findProperty('pipelineBomVersion') ?: '0.2.1-SNAPSHOT'
+
+scmVersion {
+    tag {
+        prefix = 'v'
+    }
+    checks {
+        uncommittedChanges = false
+        aheadOfRemote = false
+        snapshotDependencies = false
+    }
+}
+
+def pipelineBomVersion = findProperty('pipelineBomVersion') ?: '0.2.2'
 def pipestreamDataVersion = findProperty('pipestreamDataVersion') ?: '0.2.1'
 
 dependencies {
@@ -18,13 +32,11 @@ dependencies {
     implementation libs.quarkus.arc
     implementation libs.quarkus.rest
     implementation libs.quarkus.grpc
-    // Core Quarkus dependencies
     implementation 'io.quarkus:quarkus-smallrye-health'
     implementation 'io.quarkus:quarkus-smallrye-stork'
     implementation 'io.quarkus:quarkus-opentelemetry'
 
     // REST API dependencies
-    implementation 'io.quarkus:quarkus-rest'
     implementation 'io.quarkus:quarkus-rest-jackson'
     implementation 'io.quarkus:quarkus-smallrye-openapi'
     implementation 'io.quarkus:quarkus-micrometer-registry-prometheus'
@@ -41,12 +53,6 @@ dependencies {
     // SSL support
     implementation 'io.quarkus:quarkus-elytron-security'
 
-
-    testImplementation libs.pipestream.grpc.wiremock
-
-    // Test data dependencies - sample documents published as Maven artifacts
-    testImplementation "ai.pipestream.testdata:sample-doc-types:${pipestreamDataVersion}"
-    testImplementation "ai.pipestream.testdata:test-documents:${pipestreamDataVersion}"
     // Pipestream libraries - versions managed entirely by the BOM/catalog
     implementation libs.pipestream.compose.devservices
     implementation libs.pipestream.grpc.stubs
@@ -55,24 +61,27 @@ dependencies {
     implementation libs.pipestream.dynamic.grpc.registration.clients
 
     // Test dependencies
+    testImplementation libs.pipestream.grpc.wiremock
+    testImplementation "ai.pipestream.testdata:sample-doc-types:${pipestreamDataVersion}"
+    testImplementation "ai.pipestream.testdata:test-documents:${pipestreamDataVersion}"
     testImplementation 'io.quarkus:quarkus-junit5'
     testImplementation 'io.rest-assured:rest-assured'
     testImplementation 'io.grpc:grpc-services'
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'org.testcontainers:junit-jupiter'
-
-    // Mockito for mocking in tests
     testImplementation 'org.mockito:mockito-core'
     testImplementation 'org.mockito:mockito-junit-jupiter'
     testImplementation 'io.quarkus:quarkus-junit5-mockito'
 }
 
-group = 'ai.pipestream.module'
-version = "${pipelineBomVersion}"
+group = 'ai.pipestream'
+version = "${scmVersion.version}"
 
 java {
     sourceCompatibility = JavaVersion.VERSION_21
     targetCompatibility = JavaVersion.VERSION_21
+    withJavadocJar()
+    withSourcesJar()
 }
 
 test {
@@ -94,8 +103,8 @@ publishing {
         maven(MavenPublication) {
             from components.java
             pom {
-                name.set('Platform Registration Service')
-                description.set('Central service registry and discovery for the Pipeline platform')
+                name.set('Module Proxy')
+                description.set('gRPC proxy service for pipeline module orchestration in the Pipestream platform')
                 url.set('https://github.com/ai-pipestream/module-proxy')
 
                 licenses {
@@ -125,17 +134,40 @@ publishing {
         // Publish to Maven Local for development
         mavenLocal()
 
+        // Conditionally add GitHub Packages repository when credentials are available
+        def ghRepo = System.getenv('GITHUB_REPOSITORY') ?: 'ai-pipestream/module-proxy'
+        def ghActor = System.getenv('GITHUB_ACTOR') ?: (project.findProperty('gpr.user') ?: System.getenv('GPR_USER'))
+        def ghToken = System.getenv('GITHUB_TOKEN') ?: (project.findProperty('gpr.key') ?: System.getenv('GPR_TOKEN'))
+        if (ghActor && ghToken) {
+            maven {
+                name = 'GitHubPackages'
+                url = uri("https://maven.pkg.github.com/${ghRepo}")
+                credentials {
+                    username = ghActor
+                    password = ghToken
+                }
+            }
+        }
     }
 }
 
 signing {
-    def signingKey = System.getenv("GPG_SIGNING_KEY")
-    def signingPassword = System.getenv("GPG_SIGNING_PASSPHRASE")
+    // Read org-level GPG secrets directly, so runnable apps don't need extra env mapping
+    def signingKey = System.getenv("GPG_PRIVATE_KEY")
+    def signingPassword = System.getenv("GPG_PASSPHRASE")
 
     if (signingKey && signingPassword) {
         useInMemoryPgpKeys(signingKey, signingPassword)
         sign publishing.publications.maven
     }
+}
+
+// Ensure all signing tasks run before nmcp bundles and publishes artifacts
+afterEvaluate {
+    tasks.matching { it.name.startsWith("nmcpZipAllPublications") || it.name.startsWith("nmcpPublishAllPublicationsToCentralPortal") }
+        .configureEach { nmcpTask ->
+            nmcpTask.dependsOn(tasks.withType(Sign))
+        }
 }
 
 nmcp {


### PR DESCRIPTION
- Add axion-release plugin (v1.21.0) for automated semantic versioning
- Configure scmVersion with 'v' prefix tags and relaxed checks
- Update build.gradle to use scmVersion.version for project version
- Add withJavadocJar() and withSourcesJar() for proper artifact publishing
- Configure GitHub Packages repository for CI convenience
- Update GPG signing to use GPG_PRIVATE_KEY and GPG_PASSPHRASE env vars
- Add afterEvaluate block to ensure signing runs before NMCP tasks
- Upgrade NMCP plugin from 1.2.0 to 1.2.1
- Update default pipelineBomVersion to 0.2.2
- Correct group from 'ai.pipestream.module' to 'ai.pipestream'
- Update POM metadata to reflect Module Proxy service

Add GitHub Actions workflows:
- build-and-publish.yml: CI builds, tests, snapshot publishing, Docker snapshots
- release-and-publish.yml: Manual release with versioning, Maven Central, GitHub releases, Docker production images
- dockerhub-publish.yml: Mirror production images to Docker Hub

This aligns module-proxy with platform-registration-service and account-service build standards.